### PR TITLE
Add a `castType` property to type functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import type { SbvrType } from './type-utils';
+
 import * as BigInteger from './types/big-integer';
 import * as Boolean from './types/boolean';
 import * as CaseInsensitiveText from './types/case-insensitive-text';
@@ -17,21 +19,6 @@ import * as SHA from './types/sha';
 import * as ShortText from './types/short-text';
 import * as Text from './types/text';
 import * as Time from './types/time';
-
-type DatabaseType = string | ((necessity: string, index: string) => string);
-interface Type {
-	types: {
-		odata: {
-			name: string;
-			complexType?: string;
-		};
-		postgres: DatabaseType;
-		mysql: DatabaseType;
-		websql: DatabaseType;
-	};
-	fetchProcessing?: (field: any) => any;
-	validate: (value: any, required?: boolean) => Promise<any>;
-}
 
 export = {
 	'Big Integer': BigInteger,
@@ -54,8 +41,8 @@ export = {
 	Text,
 	Time,
 } as {
-	Hashed: Type & {
+	Hashed: SbvrType & {
 		compare: (str: string, hash: string) => Promise<boolean>;
 	};
-	[fieldType: string]: Type;
+	[fieldType: string]: SbvrType;
 };

--- a/src/type-utils.ts
+++ b/src/type-utils.ts
@@ -1,3 +1,22 @@
+export interface DatabaseTypeFn {
+	(necessity: string, index: string): string;
+	castType: string;
+}
+export type DatabaseType = string | DatabaseTypeFn;
+export interface SbvrType {
+	types: {
+		odata: {
+			name: string;
+			complexType?: string;
+		};
+		postgres: DatabaseType;
+		mysql: DatabaseType;
+		websql: DatabaseType;
+	};
+	fetchProcessing?: (field: any) => any;
+	validate: (value: any, required?: boolean) => Promise<any>;
+}
+
 const equality = (from: string, to: string) => ['Equals', from, to];
 const checkRequired = <T>(validateFn: (value: any) => T) => {
 	function runCheck(value: any, required: true): Promise<T>;

--- a/src/types/boolean.ts
+++ b/src/types/boolean.ts
@@ -1,10 +1,11 @@
 import * as TypeUtils from '../type-utils';
 
-const typeFunc = (
+const typeFunc: TypeUtils.DatabaseTypeFn = (
 	necessity: string,
 	index: string,
 	defaultValue = ' DEFAULT 0',
 ) => 'INTEGER' + defaultValue + necessity + index;
+typeFunc.castType = 'INTEGER';
 
 export const types = {
 	postgres: typeFunc,

--- a/src/types/serial.ts
+++ b/src/types/serial.ts
@@ -1,11 +1,23 @@
 import * as TypeUtils from '../type-utils';
 
+const mysqlType: TypeUtils.DatabaseTypeFn = (
+	necessity: string,
+	index: string,
+	defaultValue = '',
+) => 'INTEGER' + defaultValue + necessity + index + ' AUTO_INCREMENT';
+mysqlType.castType = 'INTEGER';
+
+const websqlType: TypeUtils.DatabaseTypeFn = (
+	necessity: string,
+	index: string,
+	defaultValue = '',
+) => 'INTEGER' + defaultValue + necessity + index + ' AUTOINCREMENT';
+websqlType.castType = 'INTEGER';
+
 export const types = {
 	postgres: 'SERIAL',
-	mysql: (necessity: string, index: string, defaultValue = '') =>
-		'INTEGER' + defaultValue + necessity + index + ' AUTO_INCREMENT',
-	websql: (necessity: string, index: string, defaultValue = '') =>
-		'INTEGER' + defaultValue + necessity + index + ' AUTOINCREMENT',
+	mysql: mysqlType,
+	websql: websqlType,
 	odata: {
 		name: 'Edm.Int64',
 	},


### PR DESCRIPTION
This allows specifying the correct type to cast to when necessary
rather than relying on the fact the currently all type functions happen
to be integers

Change-type: patch