### PR TITLE
Add support for the `starts with`, `ends with` and `contains` verb to the text type

### DIFF
--- a/Type.sbvr
+++ b/Type.sbvr
@@ -78,6 +78,9 @@ Fact type:  Text1 starts with Text2
 
 Fact type:  Text1 ends with Text2
 
+Fact type:  Text1 contains Text2
+	Synonymous Form: Text2 is contained in Text1
+
 Term:       Short Text
 	Concept Type: Text
 	--Necessity: each Short Text has a Length that is less than or equal to 255.

--- a/Type.sbvr
+++ b/Type.sbvr
@@ -74,6 +74,8 @@ Fact type:  Text1 is equal to Text2
 	Synonymous Form: Text1 equals Text2
 	Synonymous Form: Text2 equals Text1
 
+Fact type:  Text1 starts with Text2
+
 Term:       Short Text
 	Concept Type: Text
 	--Necessity: each Short Text has a Length that is less than or equal to 255.

--- a/Type.sbvr
+++ b/Type.sbvr
@@ -76,6 +76,8 @@ Fact type:  Text1 is equal to Text2
 
 Fact type:  Text1 starts with Text2
 
+Fact type:  Text1 ends with Text2
+
 Term:       Short Text
 	Concept Type: Text
 	--Necessity: each Short Text has a Length that is less than or equal to 255.

--- a/src/types/text.ts
+++ b/src/types/text.ts
@@ -20,6 +20,8 @@ export const nativeFactTypes = {
 		...TypeUtils.nativeFactTypeTemplates.equality,
 		'starts with': (from: string, to: string) => ['Startswith', from, to],
 		'ends with': (from: string, to: string) => ['Endswith', from, to],
+		contains: (from: string, to: string) => ['Contains', from, to],
+		'is contained in': (from: string, to: string) => ['Contains', to, from],
 	},
 };
 

--- a/src/types/text.ts
+++ b/src/types/text.ts
@@ -19,6 +19,7 @@ export const nativeFactTypes = {
 	Text: {
 		...TypeUtils.nativeFactTypeTemplates.equality,
 		'starts with': (from: string, to: string) => ['Startswith', from, to],
+		'ends with': (from: string, to: string) => ['Endswith', from, to],
 	},
 };
 

--- a/src/types/text.ts
+++ b/src/types/text.ts
@@ -16,7 +16,10 @@ export const nativeProperties = {
 };
 
 export const nativeFactTypes = {
-	Text: TypeUtils.nativeFactTypeTemplates.equality,
+	Text: {
+		...TypeUtils.nativeFactTypeTemplates.equality,
+		'starts with': (from: string, to: string) => ['Startswith', from, to],
+	},
 };
 
 export const validate = TypeUtils.validate.text();


### PR DESCRIPTION
```sql
-- It is necessary that each release that should manage a device and belongs to an application that is public, belongs to an application that is public and is not host and has a slug that starts with "balena_os".
SELECT NOT EXISTS (
	SELECT 1
	FROM "release" AS "release.0"
	WHERE EXISTS (
		SELECT 1
		FROM "device" AS "device.1"
		WHERE "device.1"."should be managed by-release" = "release.0"."id"
	)
	AND EXISTS (
		SELECT 1
		FROM "application" AS "application.2"
		WHERE "application.2"."is public" = 1
		AND "release.0"."belongs to-application" = "application.2"."id"
	)
	AND NOT EXISTS (
		SELECT 1
		FROM "application" AS "application.3"
		WHERE "application.3"."is public" = 1
		AND "application.3"."is host" = 0
		AND "application.3"."slug" LIKE (REPLACE(REPLACE(REPLACE($1, '\', '\\'), '_', '\_'), '%', '\%') || '%')
		AND "application.3"."slug" IS NOT NULL
		AND "release.0"."belongs to-application" = "application.3"."id"
	)
) AS "result";

-- It is necessary that each release that should manage a device and belongs to an application that is public, belongs to an application that is public and is not host and has a slug that ends with "balena_os".
SELECT NOT EXISTS (
	SELECT 1
	FROM "release" AS "release.0"
	WHERE EXISTS (
		SELECT 1
		FROM "device" AS "device.1"
		WHERE "device.1"."should be managed by-release" = "release.0"."id"
	)
	AND EXISTS (
		SELECT 1
		FROM "application" AS "application.2"
		WHERE "application.2"."is public" = 1
		AND "release.0"."belongs to-application" = "application.2"."id"
	)
	AND NOT EXISTS (
		SELECT 1
		FROM "application" AS "application.3"
		WHERE "application.3"."is public" = 1
		AND "application.3"."is host" = 0
		AND "application.3"."slug" LIKE ('%' || REPLACE(REPLACE(REPLACE($1, '\', '\\'), '_', '\_'), '%', '\%'))
		AND "application.3"."slug" IS NOT NULL
		AND "release.0"."belongs to-application" = "application.3"."id"
	)
) AS "result";

-- It is necessary that each release that should manage a device and belongs to an application that is public, belongs to an application that is public and is not host and has a slug that contains "balena_os".
SELECT NOT EXISTS (
	SELECT 1
	FROM "release" AS "release.0"
	WHERE EXISTS (
		SELECT 1
		FROM "device" AS "device.1"
		WHERE "device.1"."should be managed by-release" = "release.0"."id"
	)
	AND EXISTS (
		SELECT 1
		FROM "application" AS "application.2"
		WHERE "application.2"."is public" = 1
		AND "release.0"."belongs to-application" = "application.2"."id"
	)
	AND NOT EXISTS (
		SELECT 1
		FROM "application" AS "application.3"
		WHERE "application.3"."is public" = 1
		AND "application.3"."is host" = 0
		AND "application.3"."slug" LIKE ('%' || REPLACE(REPLACE(REPLACE($1, '\', '\\'), '_', '\_'), '%', '\%') || '%')
		AND "application.3"."slug" IS NOT NULL
		AND "release.0"."belongs to-application" = "application.3"."id"
	)
) AS "result";

-- It is necessary that each release that should manage a device and belongs to an application that is public, belongs to an application that is public and is not host and has a slug that is contained in "balena_os".
SELECT NOT EXISTS (
	SELECT 1
	FROM "release" AS "release.0"
	WHERE EXISTS (
		SELECT 1
		FROM "device" AS "device.1"
		WHERE "device.1"."should be managed by-release" = "release.0"."id"
	)
	AND EXISTS (
		SELECT 1
		FROM "application" AS "application.2"
		WHERE "application.2"."is public" = 1
		AND "release.0"."belongs to-application" = "application.2"."id"
	)
	AND NOT EXISTS (
		SELECT 1
		FROM "application" AS "application.3"
		WHERE "application.3"."is public" = 1
		AND "application.3"."is host" = 0
		AND $1 LIKE ('%' || REPLACE(REPLACE(REPLACE("application.3"."slug", '\', '\\'), '_', '\_'), '%', '\%') || '%')
		AND "application.3"."slug" IS NOT NULL
		AND "release.0"."belongs to-application" = "application.3"."id"
	)
) AS "result";
```

Change-type: minor