### PR TITLE
Add `is before` & `is after` verbs to the Date & DateTime types

### DIFF
--- a/Type.sbvr
+++ b/Type.sbvr
@@ -52,6 +52,20 @@ Fact type:  Real1 is equal to Real2
 	Synonymous Form: Real1 equals Real2
 	Synonymous Form: Real2 equals Real1
 
+Fact type:  Date1 is before Date2
+	Synonymous Form: Date2 is after Date1
+Fact type:  Date1 is equal to Date2
+	Synonymous Form: Date2 is equal to Date1
+	Synonymous Form: Date1 equals Date2
+	Synonymous Form: Date2 equals Date1
+
+Fact type:  Date Time1 is before Date Time2
+	Synonymous Form: Date Time2 is after Date Time1
+Fact type:  Date Time1 is equal to Date Time2
+	Synonymous Form: Date Time2 is equal to Date Time1
+	Synonymous Form: Date Time1 equals Date Time2
+	Synonymous Form: Date Time2 equals Date Time1
+
 
 Fact type:  Real is less than Integer
 	Synonymous Form: Integer is greater than Real

--- a/src/types/date-time.ts
+++ b/src/types/date-time.ts
@@ -16,4 +16,12 @@ export const fetchProcessing = (data: any) => {
 	return data;
 };
 
+export const nativeFactTypes = {
+	'Date Time': {
+		...TypeUtils.nativeFactTypeTemplates.equality,
+		'is before': (from: string, to: string) => ['LessThan', from, to],
+		'is after': (from: string, to: string) => ['GreaterThan', from, to],
+	},
+};
+
 export const validate = TypeUtils.validate.date;

--- a/src/types/date.ts
+++ b/src/types/date.ts
@@ -16,4 +16,12 @@ export const fetchProcessing = (data: any) => {
 	return data;
 };
 
+export const nativeFactTypes = {
+	Date: {
+		...TypeUtils.nativeFactTypeTemplates.equality,
+		'is before': (from: string, to: string) => ['LessThan', from, to],
+		'is after': (from: string, to: string) => ['GreaterThan', from, to],
+	},
+};
+
 export const validate = TypeUtils.validate.date;


### PR DESCRIPTION
Draft b/c I haven't finished testing this.

Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>