### PR TITLE
Assert that JSON input typeof is object

### DIFF
--- a/src/types/json.ts
+++ b/src/types/json.ts
@@ -12,6 +12,11 @@ export const types = {
 export const fetchProcessing = (data: any) => JSON.parse(data);
 
 export const validate = TypeUtils.validate.checkRequired((value) => {
+	// Disallow primitives
+	if (typeof value !== 'object') {
+		throw new Error(`is not an object/array: ${typeof value}`);
+	}
+
 	try {
 		return JSON.stringify(value);
 	} catch {

--- a/test/JSON.js
+++ b/test/JSON.js
@@ -18,7 +18,15 @@ helpers.describe('JSON', function (test) {
 	describe('validate', function () {
 		test.validate(obj, true, JSON.stringify(obj));
 		test.validate(arr, true, JSON.stringify(arr));
-		test.validate(num, true, JSON.stringify(num));
-		test.validate(str, true, JSON.stringify(str));
+		test.validate(
+			num,
+			false,
+			new Error(`is not an object/array: ${typeof num}`),
+		);
+		test.validate(
+			str,
+			false,
+			new Error(`is not an object/array: ${typeof str}`),
+		);
 	});
 });


### PR DESCRIPTION
Ensure that the input passed in for JSON types is either an object or an array (typeof returns 'object' for arrays as well). This change is mainly to prevent primitives from being stored as JSON.

Change-type: major
Signed-off-by: Josh Bowling <josh@monarci.com>