### PR TITLE
Switch from `new Buffer` to `Buffer.from` to avoid deprecation warnings

### DIFF
--- a/src/types/file.ts
+++ b/src/types/file.ts
@@ -26,7 +26,7 @@ export const validate = TypeUtils.validate.checkRequired((value) => {
 		);
 	}
 	try {
-		return new Buffer(value, 'hex');
+		return Buffer.from(value, 'hex');
 	} catch (e: any) {
 		throw new Error(`could not be converted to binary: ${e.message}`);
 	}

--- a/test/File.js
+++ b/test/File.js
@@ -3,7 +3,7 @@ import * as helpers from './helpers';
 helpers.describe('File', (test) =>
 	describe('validate', function () {
 		const hex = '5261777221';
-		const buf = new Buffer(hex, 'hex');
+		const buf = Buffer.from(hex, 'hex');
 		test.validate(buf, true, buf);
 		test.validate(hex, true, buf);
 		test.validate(


### PR DESCRIPTION
Change-type: patch