### PR TITLE
Explicitly type the `compare` function for `hashed`

### DIFF
--- a/src/types/hashed.ts
+++ b/src/types/hashed.ts
@@ -30,4 +30,7 @@ export const validate: TypeUtils.Validate<Types['Write'], DbWriteType> =
 		return bcrypt.hash(value, salt);
 	});
 
-export const compare = bcrypt.compare.bind(bcrypt);
+export const compare: (
+	data: string | Buffer,
+	encrypted: string,
+) => Promise<boolean> = bcrypt.compare.bind(bcrypt);


### PR DESCRIPTION
This avoids the need for downstream users to have the bcrypt types available whilst also avoiding accidental breaking changes

Change-type: patch