### PR TITLE
Update BigInteger and BigSerial TsTypes

### DIFF
--- a/src/types/big-integer.ts
+++ b/src/types/big-integer.ts
@@ -9,7 +9,7 @@ export const types = {
 	},
 };
 
-export type Types = TypeUtils.TsTypes<bigint, number | bigint>;
+export type Types = TypeUtils.TsTypes<string, string | number | bigint>;
 type DbWriteType = bigint;
 
 export const fetchProcessing: TypeUtils.FetchProcessing<Types['Read']> = (
@@ -18,11 +18,11 @@ export const fetchProcessing: TypeUtils.FetchProcessing<Types['Read']> = (
 	if (data == null) {
 		return data;
 	}
-	let value: bigint;
-	if (typeof data === 'bigint') {
+	let value: string;
+	if (typeof data === 'string') {
 		value = data;
-	} else if (typeof data === 'string' || typeof data === 'number') {
-		value = BigInt(data);
+	} else if (typeof data === 'bigint' || typeof data === 'number') {
+		value = data.toString();
 	} else {
 		throw new Error('Fetched bigint is not valid: ' + typeof data);
 	}

--- a/src/types/big-serial.ts
+++ b/src/types/big-serial.ts
@@ -24,7 +24,7 @@ export const types = {
 	},
 };
 
-export type Types = TypeUtils.TsTypes<bigint, number | bigint>;
+export type Types = TypeUtils.TsTypes<string, string | number | bigint>;
 type DbWriteType = bigint;
 
 export const validate: TypeUtils.Validate<Types['Write'], DbWriteType> =

--- a/test/Big Integer.ts
+++ b/test/Big Integer.ts
@@ -4,12 +4,13 @@ helpers.describe('Big Integer', (test) => {
 	const testBigIntString = String(Number.MAX_SAFE_INTEGER) + '00000001';
 
 	describe('fetchProcessing', function () {
-		test.fetch(1, BigInt(1));
-		test.fetch('1', BigInt(1));
-		test.fetch('1', BigInt(1));
-		test.fetch(BigInt(testBigIntString), BigInt(testBigIntString));
-		test.fetch(testBigIntString, BigInt(testBigIntString));
+		test.fetch(BigInt(1), '1');
+		test.fetch(1, '1');
+		test.fetch('1', '1');
+		test.fetch(testBigIntString, testBigIntString);
+		test.fetch(BigInt(testBigIntString), testBigIntString);
 		test.fetch({}, new Error('Fetched bigint is not valid: object'));
+		test.fetch(null, null);
 	});
 
 	describe('validate', function () {

--- a/test/Big Serial.ts
+++ b/test/Big Serial.ts
@@ -26,11 +26,13 @@ helpers.describe('Big Serial', function (test) {
 	const testBigIntString = String(Number.MAX_SAFE_INTEGER) + '00000001';
 
 	describe('fetchProcessing', function () {
-		test.fetch(1, BigInt(1));
-		test.fetch('1', BigInt(1));
-		test.fetch('1', BigInt(1));
-		test.fetch(BigInt(testBigIntString), BigInt(testBigIntString));
-		test.fetch(testBigIntString, BigInt(testBigIntString));
+		test.fetch(BigInt(1), '1');
+		test.fetch(1, '1');
+		test.fetch('1', '1');
+		test.fetch(testBigIntString, testBigIntString);
+		test.fetch(BigInt(testBigIntString), testBigIntString);
+		test.fetch({}, new Error('Fetched bigint is not valid: object'));
+		test.fetch(null, null);
 	});
 
 	describe('validate', function () {


### PR DESCRIPTION
Return big integer values as strings instead of bigint as we need to parse them back into strings anyway when returning data from pine. The new logic and types closely follow the same pattern we have for dates.

Change-type: major