### PR TITLE
Use big integer for webresource casting type

### DIFF
--- a/src/types/web-resource.ts
+++ b/src/types/web-resource.ts
@@ -68,7 +68,7 @@ export const nativeProperties: TypeUtils.NativeProperties = {
 				referencedField,
 				['TextArray', ['EmbeddedText', 'size']],
 			],
-			'Integer',
+			'Big Integer',
 		],
 	},
 };


### PR DESCRIPTION
File uploads might have very very large payloads. A simple constraint of 10GB would already break Integer type, thus, casting them as `Big Integer` when comparing.


See: https://balena.fibery.io/search/OeKvk#Work/Project/Define-release-assets-guardrails-and-limits-1161
Change-type: minor