### PR TITLE
Add support for a Length property to the JSON type

### DIFF
--- a/Type.sbvr
+++ b/Type.sbvr
@@ -40,6 +40,11 @@ Fact type:  Text has Length
 	Note: Length in characters
 	Necessity: Each Text has exactly one Length
 
+-- I guess this isn't even necessary since atm JSON has Concept Type: Text
+Fact type:  JSON has Length
+	Note: Length in characters
+	Necessity: Each TJSON has exactly one Length
+
 Fact type:  Integer1 is less than Integer2
 	Synonymous Form: Integer2 is greater than Integer1
 Fact type: Integer1 is less than or equal to Integer2

--- a/src/types/json.ts
+++ b/src/types/json.ts
@@ -1,4 +1,5 @@
 import * as TypeUtils from '../type-utils';
+import type { CharacterLengthNode } from '@balena/abstract-sql-compiler';
 
 export const types = {
 	postgres: 'JSONB',
@@ -25,6 +26,15 @@ export type Types = TypeUtils.TsTypes<
 	{ [key: string]: JSONable } | JSONable[]
 >;
 type DbWriteType = string;
+
+export const nativeProperties: TypeUtils.NativeProperties = {
+	has: {
+		Length: (referencedField): CharacterLengthNode => [
+			'CharacterLength',
+			['Cast', referencedField, 'Text'],
+		],
+	},
+};
 
 export const fetchProcessing: TypeUtils.FetchProcessing<Types['Read']> = (
 	data,


### PR DESCRIPTION
Depends-on: https://github.com/balena-io-modules/sbvr-types/pull/127
Change-type: minor
See: https://balena.fibery.io/Work/Project/API-Limit-size-of-large-fields-975