### PR TITLE
Add the 'is represented by Text' property to the JSON type

### DIFF
--- a/Type.sbvr
+++ b/Type.sbvr
@@ -40,6 +40,10 @@ Fact type:  Text has Length
 	Note: Length in characters
 	Necessity: Each Text has exactly one Length
 
+Fact type:  JSON is represented by Text
+	Note: Casts the JSON to a text string
+	Necessity: Each JSON is represented by exactly one Text
+
 Fact type:  Integer1 is less than Integer2
 	Synonymous Form: Integer2 is greater than Integer1
 Fact type: Integer1 is less than or equal to Integer2

--- a/src/types/json.ts
+++ b/src/types/json.ts
@@ -1,4 +1,5 @@
 import * as TypeUtils from '../type-utils';
+import type { CastNode } from '@balena/abstract-sql-compiler';
 
 export const types = {
 	postgres: 'JSONB',
@@ -25,6 +26,12 @@ export type Types = TypeUtils.TsTypes<
 	{ [key: string]: JSONable } | JSONable[]
 >;
 type DbWriteType = string;
+
+export const nativeProperties: TypeUtils.NativeProperties = {
+	'is represented by': {
+		Text: (referencedField): CastNode => ['Cast', referencedField, 'Text'],
+	},
+};
 
 export const fetchProcessing: TypeUtils.FetchProcessing<Types['Read']> = (
 	data,


### PR DESCRIPTION
Change-type: minor
See: https://balena.fibery.io/Work/Project/API-Limit-size-of-large-fields-975
See: https://balena.fibery.io/Work/Project/API-Limit-the-size-of-JSON-fields-1723