### PR TITLE
Fix the JSON type being incorrectly marked as Concept Type of Text

### DIFF
--- a/Type.sbvr
+++ b/Type.sbvr
@@ -21,7 +21,6 @@ Term:       Case Insensitive Text
 	Concept Type: Text
 	Note: A 'Text' type that is compared case insensitively.
 Term:       JSON
-	Concept Type: Text
 	Note: A 'Text' type that will only allow valid JSON.
 Term:       Hashed
 	Concept Type: Text


### PR DESCRIPTION
Change-type: patch
See: https://balena.fibery.io/Work/Project/API-Limit-the-size-of-JSON-fields-1723
See: #63